### PR TITLE
docs: document chat env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Build for production:
 npm run build
 ```
 
+## Environment Variables
+- `OPENAI_API_KEY`: API key for OpenAI used in chat-based interactions.
+- `REDIS_URL`: Connection string for the Redis instance used to store chat logs and memory.
+
 ## Notes
 - Uses Vite, React, and Tailwind CSS.
 - See `package.json` for scripts and additional details.


### PR DESCRIPTION
## Summary
- note OpenAI and Redis env vars for chat and logging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad421cec748333901a499840175316