### PR TITLE
feat: power all modules with gpt

### DIFF
--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -8,6 +8,7 @@ import { prefersReducedMotion } from "../lib/theme";
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:"[TX-301] Research Deck online. Ask any cosmic question."}]);
   const [conversationId] = useState(() => crypto.randomUUID());
+  const system = "You are the Research Deck AI. Answer cosmic questions concisely.";
   const reduced = useMemo(()=>prefersReducedMotion(),[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();
@@ -16,7 +17,7 @@ export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ conversationId, message: t })
+        body: JSON.stringify({ conversationId, message: t, system })
       });
       const data = await res.json();
       setMsgs(m=>[...m,{role:'assistant',text:data.reply}]);


### PR DESCRIPTION
## Summary
- extend chat API to accept system prompts for contextual GPT replies
- wire Exploration Bay and Math Lab consoles to GPT backend
- include system context for Research Deck conversations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad457a9e0c83339c18eb5f9ebad371