### PR TITLE
feat: configure OpenAI model via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 OPENAI_API_KEY=your_openai_api_key
 REDIS_URL=redis://localhost:6379
 PORT=3001
+OPENAI_MODEL=gpt-3.5-turbo

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm run build
 ## Environment Variables
 - `OPENAI_API_KEY`: API key for OpenAI used in chat-based interactions.
 - `REDIS_URL`: Connection string for the Redis instance used to store chat logs and memory.
+- `OPENAI_MODEL`: GPT model identifier used for chat completions.
 
 ## Notes
 - Uses Vite, React, and Tailwind CSS.

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,8 @@ await redis.connect();
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+const model = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+
 app.post('/api/chat', async (req, res) => {
   const { conversationId, message, system } = req.body;
   if (!conversationId || !message) {
@@ -30,7 +32,7 @@ app.post('/api/chat', async (req, res) => {
     { role: 'user', content: message },
   ];
   const completion = await openai.chat.completions.create({
-    model: 'gpt-3.5-turbo',
+    model,
     messages,
   });
   const reply = completion.choices[0]?.message?.content || '';


### PR DESCRIPTION
## Summary
- allow selecting OpenAI model via OPENAI_MODEL env var
- document new OPENAI_MODEL in .env example and README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad46a5c8708333a353236cf8d0de13