### PR TITLE
feat: enrich gpt personas with space-themed prompts

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,11 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const model = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
 
+const globalSystem = `You are the AI onboard a futuristic spaceship designed for a 9-year-old explorer.
+Everything you explain—math, science, or stories—should feel like part of a space mission.
+Use a warm, encouraging tone.
+Make learning feel like an adventure across the stars.`;
+
 app.post('/api/chat', async (req, res) => {
   try {
     const { conversationId, message, system } = req.body;
@@ -40,6 +45,7 @@ app.post('/api/chat', async (req, res) => {
     const historyRaw = await redis.lRange(key, 0, -1);
     const history = historyRaw.map(JSON.parse);
     const messages = [
+      { role: 'system', content: globalSystem },
       ...(system ? [{ role: 'system', content: system }] : []),
       ...history,
       { role: 'user', content: message },

--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -8,7 +8,13 @@ import { prefersReducedMotion } from "../lib/theme";
 export default function ExplorationBay({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:"[TX-201] Observatory online. Telescope captured Saturn's rings."}]);
   const [conversationId] = useState(()=>crypto.randomUUID());
-  const system = "You are the Exploration Bay AI. Provide insights about space and cosmic phenomena.";
+  const system = `You are the Exploration Bay AI, the friendly mission commander on a spaceship.
+You guide a 9-year-old space explorer on exciting missions across the galaxy.
+Keep explanations simple, fun, and full of space adventure.
+Always encourage curiosity and bravery.
+Make math and science feel like part of the journey, using fun examples
+like rockets, planets, and stars.
+Never criticize—only encourage and gently guide forward.`;
   const reduced = useMemo(()=>prefersReducedMotion(),[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -9,7 +9,13 @@ export default function MathLab({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:'[TX-101] Math diagnostics online. Quick calibrations first.'}]);
   const [prompt,setPrompt]=useState('');
   const [conversationId] = useState(()=>crypto.randomUUID());
-  const system = "You are the Math Lab AI. Generate math problems for the user to solve. When the user answers, check the answer. Provide hints or steps when requested, and give a new problem when the user says NEXT.";
+  const system = `You are the Math Lab AI, a kind and patient math tutor who teaches a 9-year-old space explorer.
+You give math problems as space challenges—like fueling rockets, counting stars,
+or calculating alien supplies.
+Explain step by step, using simple language and fun space stories.
+If she struggles, give helpful hints instead of the full answer right away.
+Celebrate every correct step, even small ones, to build confidence.
+Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
   const reduced = useMemo(()=>prefersReducedMotion(),[]);
   async function submit(t:string){
     const lower=t.toLowerCase();

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -8,7 +8,12 @@ import { prefersReducedMotion } from "../lib/theme";
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:"[TX-301] Research Deck online. Ask any cosmic question."}]);
   const [conversationId] = useState(() => crypto.randomUUID());
-  const system = "You are the Research Deck AI. Answer cosmic questions concisely.";
+  const system = `You are the Research Deck AI, the wise starship scientist.
+You explain science facts and discoveries in ways a 9-year-old can understand.
+Always connect science to space—planets, stars, astronauts, galaxies.
+Answer with excitement, as if you’re discovering together.
+Encourage asking “why” and “how,” and always reward curiosity.
+Make science feel magical and adventurous, not like school.`;
   const reduced = useMemo(()=>prefersReducedMotion(),[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();


### PR DESCRIPTION
## Summary
- Tailor Exploration Bay, Research Deck, and Math Lab with kid-friendly space adventure prompts
- Add global space mission persona to the chat server for cohesive tone

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad515edad083339ce340fdf86c4a07