### PR TITLE
Fix background video playback fallback

### DIFF
--- a/src/components/BackgroundCanvas.tsx
+++ b/src/components/BackgroundCanvas.tsx
@@ -47,8 +47,8 @@ export default function BackgroundCanvas({
         await v.play();
         setUseImageFallback(false);
       } catch {
-        // Autoplay blocked or failed: use fallback image
-        setUseImageFallback(true);
+        // Autoplay blocked or failed: leave video paused and show play button
+        setPlaying(false);
       }
     };
     // Start muted to satisfy browser autoplay policies


### PR DESCRIPTION
## Summary
- allow manual playback of background videos when autoplay is blocked

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad538a11e88333aab50e025eb709c1