### PR TITLE
feat: stream chat responses with loading indicator

### DIFF
--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,30 @@
+export async function streamChat({
+  conversationId,
+  message,
+  system,
+  onMessage,
+}: {
+  conversationId: string;
+  message: string;
+  system?: string;
+  onMessage: (text: string) => void;
+}): Promise<string> {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ conversationId, message, system }),
+  });
+  if (!res.body) {
+    throw new Error('No response body');
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let full = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    full += decoder.decode(value, { stream: true });
+    onMessage(full);
+  }
+  return full;
+}


### PR DESCRIPTION
## Summary
- stream OpenAI responses from the server to the client
- show a loading message then replace it with live tokens in the console
- add utility for streaming chat fetches

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad53b0ca408333a7b2320e0450a3a5