### PR TITLE
Fix chat streaming output parsing

### DIFF
--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -20,10 +20,39 @@ export async function streamChat({
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let full = '';
+  let buffer = '';
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
-    full += decoder.decode(value, { stream: true });
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex;
+    while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (typeof obj.reply === 'string') {
+          full += obj.reply;
+          onMessage(full);
+        }
+      } catch {
+        full += line;
+        onMessage(full);
+      }
+    }
+  }
+  if (buffer.trim()) {
+    try {
+      const obj = JSON.parse(buffer.trim());
+      if (typeof obj.reply === 'string') {
+        full += obj.reply;
+      } else {
+        full += buffer.trim();
+      }
+    } catch {
+      full += buffer.trim();
+    }
     onMessage(full);
   }
   return full;


### PR DESCRIPTION
## Summary
- stream server responses as newline-delimited JSON for chunk-wise parsing
- decode JSON line tokens on the client to render incremental assistant messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad55fc0f5c8333bd8a7f9da7e8950d