### PR TITLE
feat: enable autoplay for background videos

### DIFF
--- a/src/components/BackgroundCanvas.tsx
+++ b/src/components/BackgroundCanvas.tsx
@@ -90,6 +90,7 @@ export default function BackgroundCanvas({
               src={videoUrl}
               loop
               muted
+              autoPlay
               playsInline
               preload="auto"
               aria-label={label}


### PR DESCRIPTION
## Summary
- autoplay background MP4 videos by default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad65cc69fc8333b2f1110927d8f0e2