### PR TITLE
Show module video beside chat

### DIFF
--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { Console } from "../components/Console";
-import MissionCard from "../components/MissionCard";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { prefersReducedMotion } from "../lib/theme";
@@ -58,10 +57,16 @@ Never criticize—only encourage and gently guide forward.`;
           placeholder="Type or tap a command…"
           commands={[{label:'RETURN TO HUB',value:'RETURN'}]}
         />
-        <MissionCard
-          mode="explore"
-          data={{prompt:"Choose your focus:", options:["What rings are made of","How wide they stretch"]}}
-        />
+        <div className="w-full flex items-center justify-center">
+          <video
+            src="/videos/exploration-bay.mp4"
+            loop
+            autoPlay
+            muted
+            playsInline
+            className="w-full h-auto rounded"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { Console } from "../components/Console";
-import MissionCard from "../components/MissionCard";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { prefersReducedMotion } from "../lib/theme";
@@ -8,7 +7,6 @@ import { streamChat } from "../lib/chat";
 
 export default function MathLab({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:'[TX-101] Math diagnostics online. Quick calibrations first.'}]);
-  const [prompt,setPrompt]=useState('');
   const [conversationId] = useState(()=>crypto.randomUUID());
   const system = `You are the Math Lab AI, a kind and patient math tutor who teaches a 9-year-old space explorer.
 You give math problems as space challenges—like fueling rockets, counting stars,
@@ -23,7 +21,7 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
     if(lower.includes('return')) return onReturn();
     setMsgs(m=>[...m,{role:'user',text:t},{role:'assistant',text:'loading...'}]);
     try {
-      const reply = await streamChat({
+      await streamChat({
         conversationId,
         message: t,
         system,
@@ -35,7 +33,6 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
           });
         }
       });
-      if(t==='NEXT') setPrompt(reply);
     } catch(err){
       setMsgs(m=>{
         const copy=[...m];
@@ -67,12 +64,16 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
             {label:'RETURN TO HUB',value:'RETURN'}
           ]}
         />
-        <MissionCard mode="math" data={{prompt}}
-          onAnswer={(n)=>submit(String(n))}
-          onHint={()=>submit('HINT')}
-          onSteps={()=>submit('SHOW STEPS')}
-          onNext={()=>submit('NEXT')}
-        />
+        <div className="w-full flex items-center justify-center">
+          <video
+            src="/videos/math-lab.mp4"
+            loop
+            autoPlay
+            muted
+            playsInline
+            className="w-full h-auto rounded"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { Console } from "../components/Console";
-import MissionCard from "../components/MissionCard";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { prefersReducedMotion } from "../lib/theme";
@@ -65,10 +64,16 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
             {label:'RETURN TO HUB',value:'RETURN'}
           ]}
         />
-        <MissionCard
-          mode="research"
-          data={{prompt:"Any cosmic question is valid.", suggestion:"Examples: stars twinkle? live on Mars? how far is Neptune?"}}
-        />
+        <div className="w-full flex items-center justify-center">
+          <video
+            src="/videos/research-deck.mp4"
+            loop
+            autoPlay
+            muted
+            playsInline
+            className="w-full h-auto rounded"
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace mission cards in each module with an embedded looping video so chat appears on left and video on right

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad66f8cea48333833c6602ab2a99b8