### PR TITLE
Print server logs to console

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import OpenAI from 'openai';
 import { createClient } from 'redis';
-import { log } from './logger.js';
+import { log, logError } from './logger.js';
 
 dotenv.config();
 
@@ -21,7 +21,7 @@ app.use((req, res, next) => {
 });
 
 const redis = createClient({ url: process.env.REDIS_URL });
-redis.on('error', err => log(`Redis error ${err}`));
+redis.on('error', err => logError(`Redis error ${err}`));
 await redis.connect();
 log('Connected to Redis');
 
@@ -80,7 +80,7 @@ app.post('/api/chat', async (req, res) => {
     await redis.rPush(key, JSON.stringify({ role: 'assistant', content: reply }));
     res.end();
   } catch (err) {
-    log(`Error in /api/chat: ${err}`);
+    logError(`Error in /api/chat: ${err}`);
     res.status(500).json({ error: 'Internal server error' });
   }
 });
@@ -93,7 +93,7 @@ app.get('/api/chat/:conversationId', async (req, res) => {
     const history = historyRaw.map(JSON.parse);
     res.json(history);
   } catch (err) {
-    log(`Error in GET /api/chat/${req.params.conversationId}: ${err}`);
+    logError(`Error in GET /api/chat/${req.params.conversationId}: ${err}`);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/logger.js
+++ b/server/logger.js
@@ -7,12 +7,21 @@ if (!fs.existsSync(logDir)) {
 }
 const logFile = path.join(logDir, 'server.log');
 
-export function log(message) {
+function write(level, message, output) {
   const timestamp = new Date().toISOString();
-  const entry = `[${timestamp}] ${message}\n`;
-  fs.appendFile(logFile, entry, err => {
+  const entry = `[${timestamp}] [${level}] ${message}`;
+  output(entry);
+  fs.appendFile(logFile, entry + '\n', err => {
     if (err) {
       console.error('Failed to write log', err);
     }
   });
+}
+
+export function log(message) {
+  write('INFO', message, console.log);
+}
+
+export function logError(message) {
+  write('ERROR', message, console.error);
 }


### PR DESCRIPTION
## Summary
- log server activity and errors to stdout while still writing to a log file
- log Redis connection and route errors using a dedicated `logError` helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad68164050833393d1f97400803dd9