### PR TITLE
Persist stage and add dashboard navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BootScreen from './components/BootScreen';
 import Identification from './components/Identification';
 import Hub from './pages/Hub';
 import MathLab from './pages/MathLab';
 import ExplorationBay from './pages/ExplorationBay';
 import ResearchDeck from './pages/ResearchDeck';
+import type { Route } from './routes';
 
 export default function App() {
-  const [stage, setStage] = useState<'boot'|'identify'|'hub'|'math'|'explore'|'research'>('boot');
+  const [stage, setStage] = useState<Route>(() => {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('stage') : null;
+    if (saved === 'boot' || saved === 'identify' || saved === 'hub' || saved === 'math' || saved === 'explore' || saved === 'research') {
+      return saved;
+    }
+    return 'boot';
+  });
   const [name, setName] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem('stage', stage);
+  }, [stage]);
 
   if (stage === 'boot') return <BootScreen onDone={() => setStage('identify')} />;
   if (stage === 'identify') return <Identification onIdentified={n => { setName(n); setStage('hub'); }} />;

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,6 +1,17 @@
-export default function HeaderBar({ title }: { title: string }) {
+import { ArrowLeft } from "lucide-react";
+
+export default function HeaderBar({ title, onBack }: { title: string; onBack?: () => void }) {
   return (
-    <header className="w-full px-6 py-4 bg-black/40 backdrop-blur border-b border-white/10">
+    <header className="w-full px-6 py-4 bg-black/40 backdrop-blur border-b border-white/10 flex items-center gap-4">
+      {onBack && (
+        <button
+          onClick={onBack}
+          className="p-2 rounded bg-white/10 hover:bg-white/20 border border-white/20"
+        >
+          <ArrowLeft size={16} />
+          <span className="sr-only">Back to hub</span>
+        </button>
+      )}
       <h1 className="text-lg font-semibold">{title}</h1>
     </header>
   );

--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -49,7 +49,7 @@ Never criticize—only encourage and gently guide forward.`;
         reducedMotion={reduced}
         label="Exploration Bay animated background"
       />
-      <HeaderBar title="Division: Exploration Bay" />
+      <HeaderBar title="Division: Exploration Bay" onBack={onReturn} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
         <Console
           messages={msgs as any}

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -52,7 +52,7 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
         reducedMotion={reduced}
         label="Math Lab animated background"
       />
-      <HeaderBar title="Division: Math Lab" />
+      <HeaderBar title="Division: Math Lab" onBack={onReturn} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
         <Console
           messages={msgs as any}

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
@@ -20,6 +20,7 @@ Example: “Plasma is like super-hot glowing gas. Do you know what that means, o
 Always keep your tone warm, encouraging, and adventurous—like a science officer guiding a young captain on a discovery mission.
 `;
   const reduced = useMemo(()=>prefersReducedMotion(),[]);
+  useEffect(()=>{ submit('NEXT'); },[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();
     setMsgs(m=>[...m,{role:'user',text:t},{role:'assistant',text:'loading...'}]);
@@ -53,7 +54,7 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
         reducedMotion={reduced}
         label="Research Deck animated background"
       />
-      <HeaderBar title="Division: Research Deck" />
+      <HeaderBar title="Division: Research Deck" onBack={onReturn} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
         <Console
           messages={msgs as any}


### PR DESCRIPTION
## Summary
- keep current section in localStorage so refresh resumes on the same page
- add HeaderBar back button and wire it to department pages for dashboard navigation
- trigger initial message in Research Deck on mount

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68addb04f2c883339e8cdcb5c4325d3a