### PR TITLE
Disable streaming for chat interactions

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -55,31 +55,16 @@ app.post('/api/chat', async (req, res) => {
       ...history,
       { role: 'user', content: message },
     ];
-    res.setHeader('Content-Type', 'application/json; charset=utf-8');
-    // disable buffering so tokens reach the client as soon as they are generated
-    res.setHeader('Cache-Control', 'no-cache');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no');
-    // flush headers so the client starts receiving chunks immediately
-    res.flushHeaders();
     const completion = await openai.chat.completions.create({
       model,
       messages,
-      stream: true,
+      stream: false,
     });
-    let reply = '';
-    for await (const chunk of completion) {
-      const token = chunk.choices[0]?.delta?.content || '';
-      reply += token;
-      // send each token as a JSON line so the frontend can parse incrementally
-      res.write(JSON.stringify({ reply: token }) + '\n');
-      // some middleware like compression can buffer output; flush if available
-      if (typeof res.flush === 'function') res.flush();
-    }
+    const reply = completion.choices[0]?.message?.content || '';
     logger.info(`Chat reply conversationId=${conversationId} reply=${reply}`);
     await redis.rPush(key, JSON.stringify({ role: 'user', content: message }));
     await redis.rPush(key, JSON.stringify({ role: 'assistant', content: reply }));
-    res.end();
+    res.json({ reply });
   } catch (err) {
     logger.error(`Error in /api/chat: ${err}`);
     res.status(500).json({ error: 'Internal server error' });

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -14,46 +14,8 @@ export async function streamChat({
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ conversationId, message, system }),
   });
-  if (!res.body) {
-    throw new Error('No response body');
-  }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let full = '';
-  let buffer = '';
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    let newlineIndex;
-    while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
-      const line = buffer.slice(0, newlineIndex).trim();
-      buffer = buffer.slice(newlineIndex + 1);
-      if (!line) continue;
-      try {
-        const obj = JSON.parse(line);
-        if (typeof obj.reply === 'string') {
-          full += obj.reply;
-          onMessage(full);
-        }
-      } catch {
-        full += line;
-        onMessage(full);
-      }
-    }
-  }
-  if (buffer.trim()) {
-    try {
-      const obj = JSON.parse(buffer.trim());
-      if (typeof obj.reply === 'string') {
-        full += obj.reply;
-      } else {
-        full += buffer.trim();
-      }
-    } catch {
-      full += buffer.trim();
-    }
-    onMessage(full);
-  }
+  const data = await res.json();
+  const full = typeof data.reply === 'string' ? data.reply : '';
+  onMessage(full);
   return full;
 }

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -6,7 +6,12 @@ import { prefersReducedMotion } from "../lib/theme";
 import { streamChat } from "../lib/chat";
 
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
-  const [msgsnpm ,setMsgs]=useState([{role:'assistant',text:"[TX-301] Research Deck online. Ask any cosmic question."}]);
+  const [msgs, setMsgs] = useState([
+    {
+      role: 'assistant',
+      text: "[TX-301] Research Deck online. Ask any cosmic question.",
+    },
+  ]);
   const [conversationId] = useState(() => crypto.randomUUID());
   const system = `You are the Research Deck AI, the starship’s scientist for a 9-year-old explorer.
 When you answer, always break your response into **short paragraphs** (2–3 sentences each) with blank lines between them.


### PR DESCRIPTION
## Summary
- Stop streaming chat replies and fetch full responses instead
- Simplify frontend chat handler for non-streamed responses
- Fix Research Deck state initialization typo

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ade211ac008333855afc7ef62cfafa