### PR TITLE
Remove background video from Exploration Bay

### DIFF
--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -44,7 +44,6 @@ Never criticize—only encourage and gently guide forward.`;
     <div className="relative min-h-screen">
       <BackgroundCanvas
         mode="bay"
-        videoUrl="/videos/exploration-bay.mp4"
         imageUrl="/bg-explore.jpg"
         reducedMotion={reduced}
         label="Exploration Bay animated background"


### PR DESCRIPTION
## Summary
- remove background video from Exploration Bay so only the foreground video is shown

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade5e3b74c8333af7a4bc905c0eab8