### PR TITLE
Remove background videos from Math Lab and Research Deck

### DIFF
--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
-import { prefersReducedMotion } from "../lib/theme";
 import { streamChat } from "../lib/chat";
 
 export default function MathLab({onReturn}:{onReturn:()=>void}){
@@ -15,7 +14,6 @@ Explain step by step, using simple language and fun space stories.
 If she struggles, give helpful hints instead of the full answer right away.
 Celebrate every correct step, even small ones, to build confidence.
 Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
-  const reduced = useMemo(()=>prefersReducedMotion(),[]);
   async function submit(t:string){
     const lower=t.toLowerCase();
     if(lower.includes('return')) return onReturn();
@@ -45,13 +43,7 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
   useEffect(()=>{ submit('NEXT'); },[]);
   return (
     <div className="relative min-h-screen">
-      <BackgroundCanvas
-        mode="bay"
-        videoUrl="/videos/math-lab.mp4"
-        imageUrl="/bg-math.jpg"
-        reducedMotion={reduced}
-        label="Math Lab animated background"
-      />
+      <BackgroundCanvas mode="bay" imageUrl="/bg-math.jpg" reducedMotion />
       <HeaderBar title="Division: Math Lab" onBack={onReturn} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
         <Console

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
-import { prefersReducedMotion } from "../lib/theme";
 import { streamChat } from "../lib/chat";
 
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
@@ -24,7 +23,6 @@ Example: “Plasma is like super-hot glowing gas. Do you know what that means, o
 
 Always keep your tone warm, encouraging, and adventurous—like a science officer guiding a young captain on a discovery mission.
 `;
-  const reduced = useMemo(()=>prefersReducedMotion(),[]);
   useEffect(()=>{ submit('NEXT'); },[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();
@@ -52,13 +50,7 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
   }
   return (
     <div className="relative min-h-screen">
-      <BackgroundCanvas
-        mode="bay"
-        videoUrl="/videos/research-deck.mp4"
-        imageUrl="/bg-research.jpg"
-        reducedMotion={reduced}
-        label="Research Deck animated background"
-      />
+      <BackgroundCanvas mode="bay" imageUrl="/bg-research.jpg" reducedMotion />
       <HeaderBar title="Division: Research Deck" onBack={onReturn} />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
         <Console


### PR DESCRIPTION
## Summary
- Drop background videos on Math Lab and Research Deck pages to avoid layered video effect
- Simplify imports by removing unused reduced-motion logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade7e10ea88333b9309a3056c4681a