### PR TITLE
Refactor video layout into reusable component

### DIFF
--- a/src/components/VideoFrame.tsx
+++ b/src/components/VideoFrame.tsx
@@ -1,0 +1,14 @@
+export default function VideoFrame({ src }: { src: string }) {
+  return (
+    <div className="relative w-full pb-[56.25%]">
+      <video
+        src={src}
+        loop
+        autoPlay
+        muted
+        playsInline
+        className="absolute top-0 left-0 w-full h-full object-cover rounded"
+      />
+    </div>
+  );
+}

--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -4,6 +4,7 @@ import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { prefersReducedMotion } from "../lib/theme";
 import { streamChat } from "../lib/chat";
+import VideoFrame from "../components/VideoFrame";
 
 export default function ExplorationBay({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:"[TX-201] Observatory online. Telescope captured Saturn's rings."}]);
@@ -57,14 +58,7 @@ Never criticize—only encourage and gently guide forward.`;
           commands={[{label:'RETURN TO HUB',value:'RETURN'}]}
         />
         <div className="w-full flex items-center justify-center">
-          <video
-            src="/videos/exploration-bay.mp4"
-            loop
-            autoPlay
-            muted
-            playsInline
-            className="w-full h-auto rounded"
-          />
+          <VideoFrame src="/videos/exploration-bay.mp4" />
         </div>
       </div>
     </div>

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -3,6 +3,7 @@ import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { streamChat } from "../lib/chat";
+import VideoFrame from "../components/VideoFrame";
 
 export default function MathLab({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:'[TX-101] Math diagnostics online. Quick calibrations first.'}]);
@@ -57,14 +58,7 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
           ]}
         />
         <div className="w-full flex items-center justify-center">
-          <video
-            src="/videos/math-lab.mp4"
-            loop
-            autoPlay
-            muted
-            playsInline
-            className="w-full h-auto rounded"
-          />
+          <VideoFrame src="/videos/math-lab.mp4" />
         </div>
       </div>
     </div>

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -3,6 +3,7 @@ import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { streamChat } from "../lib/chat";
+import VideoFrame from "../components/VideoFrame";
 
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
   const [msgs, setMsgs] = useState([
@@ -63,14 +64,7 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
           ]}
         />
         <div className="w-full flex items-center justify-center">
-          <video
-            src="/videos/research-deck.mp4"
-            loop
-            autoPlay
-            muted
-            playsInline
-            className="w-full h-auto rounded"
-          />
+          <VideoFrame src="/videos/research-deck.mp4" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `VideoFrame` component to centralize video sizing
- use `VideoFrame` across ExplorationBay, MathLab, and ResearchDeck pages for consistent styling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade8e958dc83338ca915889f0d4d6e