### PR TITLE
Stop auto-sending NEXT on module load

### DIFF
--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
@@ -40,8 +40,6 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
       });
     }
   }
-
-  useEffect(()=>{ submit('NEXT'); },[]);
   return (
     <div className="relative min-h-screen">
       <BackgroundCanvas mode="bay" imageUrl="/bg-math.jpg" reducedMotion />

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
@@ -24,7 +24,6 @@ Example: “Plasma is like super-hot glowing gas. Do you know what that means, o
 
 Always keep your tone warm, encouraging, and adventurous—like a science officer guiding a young captain on a discovery mission.
 `;
-  useEffect(()=>{ submit('NEXT'); },[]);
   async function submit(t:string){
     if(t.toLowerCase().includes('return')) return onReturn();
     setMsgs(m=>[...m,{role:'user',text:t},{role:'assistant',text:'loading...'}]);


### PR DESCRIPTION
## Summary
- Avoid auto-triggering 'NEXT' requests in Research Deck by removing the mount-time submission and associated `useEffect` import.
- Do the same for Math Lab so sessions start only when the user asks or taps a command.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae8beb12bc8333a74b15d7115732f1