### PR TITLE
feat: rotate videos by prefix

### DIFF
--- a/src/components/VideoFrame2.tsx
+++ b/src/components/VideoFrame2.tsx
@@ -1,15 +1,41 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
 interface VideoFrame2Props {
-  sources: string[];
+  /**
+   * Base name of the video files to rotate through. Any file in
+   * `/public/videos` whose name begins with this prefix will be
+   * included in the rotation. The match is case-insensitive and
+   * whitespace is treated the same as hyphens.
+   */
+  prefix: string;
+  /** Time between video swaps in milliseconds */
   interval?: number;
 }
 
-export default function VideoFrame2({ sources, interval = 5000 }: VideoFrame2Props) {
-  const [index, setIndex] = useState(() => Math.floor(Math.random() * sources.length));
+export default function VideoFrame2({ prefix, interval = 5000 }: VideoFrame2Props) {
+  // Gather all video assets that start with the provided prefix.
+  const sources = useMemo(() => {
+    const modules = (import.meta as any).glob('/public/videos/*', { eager: true, as: 'url' });
+    const slug = prefix.toLowerCase().replace(/\s+/g, '-');
+    return Object.entries(modules)
+      .filter(([path]) => path.toLowerCase().includes(slug))
+      .map(([, url]) => url as string);
+  }, [prefix]);
+
+  const [index, setIndex] = useState(() =>
+    sources.length ? Math.floor(Math.random() * sources.length) : 0
+  );
+
+  // When the sources change, pick a new random starting index
+  useEffect(() => {
+    if (sources.length) {
+      setIndex(Math.floor(Math.random() * sources.length));
+    }
+  }, [sources]);
 
   useEffect(() => {
+    if (sources.length <= 1) return;
     const id = setInterval(() => {
       setIndex((prev) => {
         if (sources.length <= 1) return prev;
@@ -24,6 +50,7 @@ export default function VideoFrame2({ sources, interval = 5000 }: VideoFrame2Pro
   }, [sources, interval]);
 
   const src = sources[index];
+  if (!src) return null;
 
   return (
     <div className="relative w-full pb-[56.25%] overflow-hidden">

--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -4,7 +4,7 @@ import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { prefersReducedMotion } from "../lib/theme";
 import { streamChat } from "../lib/chat";
-import VideoFrame from "../components/VideoFrame";
+import VideoFrame2 from "../components/VideoFrame2";
 
 export default function ExplorationBay({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:"[TX-201] Observatory online. Telescope captured Saturn's rings."}]);
@@ -58,7 +58,7 @@ Never criticize—only encourage and gently guide forward.`;
           commands={[{label:'RETURN TO HUB',value:'RETURN'}]}
         />
         <div className="w-full flex items-center justify-center">
-          <VideoFrame src="/videos/exploration-bay.mp4" />
+          <VideoFrame2 prefix="exploration bay" />
         </div>
       </div>
     </div>

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -3,7 +3,7 @@ import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { streamChat } from "../lib/chat";
-import VideoFrame from "../components/VideoFrame";
+import VideoFrame2 from "../components/VideoFrame2";
 
 export default function MathLab({onReturn}:{onReturn:()=>void}){
   const [msgs,setMsgs]=useState([{role:'assistant',text:'[TX-101] Math diagnostics online. Quick calibrations first.'}]);
@@ -56,7 +56,7 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
           ]}
         />
         <div className="w-full flex items-center justify-center">
-          <VideoFrame src="/videos/math-lab.mp4" />
+          <VideoFrame2 prefix="math lab" />
         </div>
       </div>
     </div>

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -3,7 +3,7 @@ import { Console } from "../components/Console";
 import BackgroundCanvas from "../components/BackgroundCanvas";
 import HeaderBar from "../components/HeaderBar";
 import { streamChat } from "../lib/chat";
-import VideoFrame from "../components/VideoFrame";
+import VideoFrame2 from "../components/VideoFrame2";
 
 export default function ResearchDeck({onReturn}:{onReturn:()=>void}){
   const [msgs, setMsgs] = useState([
@@ -63,7 +63,7 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
           ]}
         />
         <div className="w-full flex items-center justify-center">
-          <VideoFrame src="/videos/research-deck.mp4" />
+          <VideoFrame2 prefix="research deck" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rotate through videos that share a prefix using `VideoFrame2`
- hook Exploration Bay, Math Lab, and Research Deck pages to the rotating video frame

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ee90b2c8333b54783337ee1da3c