### PR TITLE
Add scroll bar to chat panels

### DIFF
--- a/src/pages/ExplorationBay.tsx
+++ b/src/pages/ExplorationBay.tsx
@@ -42,7 +42,7 @@ Never criticize—only encourage and gently guide forward.`;
     }
   }
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen flex flex-col">
       <BackgroundCanvas
         mode="bay"
         imageUrl="/bg-explore.jpg"
@@ -50,14 +50,16 @@ Never criticize—only encourage and gently guide forward.`;
         label="Exploration Bay animated background"
       />
       <HeaderBar title="Division: Exploration Bay" onBack={onReturn} />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
-        <Console
-          messages={msgs as any}
-          onSubmit={submit}
-          placeholder="Type or tap a command…"
-          commands={[{label:'RETURN TO HUB',value:'RETURN'}]}
-        />
-        <div className="w-full flex items-center justify-center">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 p-6 min-h-0">
+        <div className="h-full min-h-0">
+          <Console
+            messages={msgs as any}
+            onSubmit={submit}
+            placeholder="Type or tap a command…"
+            commands={[{label:'RETURN TO HUB',value:'RETURN'}]}
+          />
+        </div>
+        <div className="w-full flex items-center justify-center h-full">
           <VideoFrame2 prefix="exploration bay" />
         </div>
       </div>

--- a/src/pages/MathLab.tsx
+++ b/src/pages/MathLab.tsx
@@ -41,21 +41,23 @@ Keep math playful, imaginative, and fun—like solving puzzles on a spaceship.`;
     }
   }
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen flex flex-col">
       <BackgroundCanvas mode="bay" imageUrl="/bg-math.jpg" reducedMotion />
       <HeaderBar title="Division: Math Lab" onBack={onReturn} />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
-        <Console
-          messages={msgs as any}
-          onSubmit={submit}
-          placeholder="Type or tap a command…"
-          commands={[
-            {label:'HINT',value:'HINT'},
-            {label:'SHOW STEPS',value:'SHOW STEPS'},
-            {label:'RETURN TO HUB',value:'RETURN'}
-          ]}
-        />
-        <div className="w-full flex items-center justify-center">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 p-6 min-h-0">
+        <div className="h-full min-h-0">
+          <Console
+            messages={msgs as any}
+            onSubmit={submit}
+            placeholder="Type or tap a command…"
+            commands={[
+              {label:'HINT',value:'HINT'},
+              {label:'SHOW STEPS',value:'SHOW STEPS'},
+              {label:'RETURN TO HUB',value:'RETURN'}
+            ]}
+          />
+        </div>
+        <div className="w-full flex items-center justify-center h-full">
           <VideoFrame2 prefix="math lab" />
         </div>
       </div>

--- a/src/pages/ResearchDeck.tsx
+++ b/src/pages/ResearchDeck.tsx
@@ -49,20 +49,22 @@ Always keep your tone warm, encouraging, and adventurous—like a science office
     }
   }
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen flex flex-col">
       <BackgroundCanvas mode="bay" imageUrl="/bg-research.jpg" reducedMotion />
       <HeaderBar title="Division: Research Deck" onBack={onReturn} />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-6">
-        <Console
-          messages={msgs as any}
-          onSubmit={submit}
-          placeholder="Ask your question or type a command…"
-          commands={[
-            {label:'NEW QUESTION',value:'NEXT'},
-            {label:'RETURN TO HUB',value:'RETURN'}
-          ]}
-        />
-        <div className="w-full flex items-center justify-center">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 p-6 min-h-0">
+        <div className="h-full min-h-0">
+          <Console
+            messages={msgs as any}
+            onSubmit={submit}
+            placeholder="Ask your question or type a command…"
+            commands={[
+              {label:'NEW QUESTION',value:'NEXT'},
+              {label:'RETURN TO HUB',value:'RETURN'}
+            ]}
+          />
+        </div>
+        <div className="w-full flex items-center justify-center h-full">
           <VideoFrame2 prefix="research deck" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix chat layout so left console doesn't expand indefinitely
- constrain page grids to available height
- wrap consoles with min-h-0/h-full containers for scrollbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae9bd5413883338254a61c0cd174c1