### PR TITLE
feat: add scrollbar to chat console

### DIFF
--- a/src/components/Console.tsx
+++ b/src/components/Console.tsx
@@ -22,7 +22,7 @@ export function Console({
     setInput('');
   };
   return (
-    <div className="bg-black/40 p-4 rounded-lg border border-white/10 flex flex-col h-full">
+    <div className="bg-black/40 p-4 rounded-lg border border-white/10 flex flex-col h-full max-h-screen overflow-hidden">
       <div className="flex-1 overflow-y-auto space-y-2 mb-2">
         {messages.map((m, i) => (
           <div


### PR DESCRIPTION
## Summary
- prevent chat interface from expanding endlessly by constraining height and enabling vertical scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae9db47c00833384c5947abfb213a1