### PR TITLE
feat: allow local network access

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import morgan from 'morgan';
 import logger from './logger.js';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 
 dotenv.config();
@@ -117,6 +118,21 @@ app.get('/videos/:name', (req, res) => {
 });
 
 const port = process.env.PORT || 3001;
-app.listen(port, () => {
-  logger.info(`Server listening on port ${port}`);
+const host = '0.0.0.0';
+
+function getLocalIp() {
+  const nets = os.networkInterfaces();
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name]) {
+      if (net.family === 'IPv4' && !net.internal) {
+        return net.address;
+      }
+    }
+  }
+  return 'localhost';
+}
+
+app.listen(port, host, () => {
+  const ip = getLocalIp();
+  logger.info(`Server listening on http://${ip}:${port}`);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '0.0.0.0',
     proxy: {
       '/api': 'http://localhost:3001'
     }


### PR DESCRIPTION
## Summary
- expose Vite dev server on 0.0.0.0 for remote access
- bind API server to 0.0.0.0 and log local network URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4b61c600883338c8bd016b6719ab2