### PR TITLE
Serve video assets from backend server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ OPENAI_API_KEY=your_openai_api_key
 REDIS_URL=redis://localhost:6379
 PORT=3001
 OPENAI_MODEL=gpt-3.5-turbo
+VITE_BACKEND_URL=http://localhost:3001

--- a/src/components/VideoFrame2.tsx
+++ b/src/components/VideoFrame2.tsx
@@ -15,19 +15,21 @@ interface VideoFrame2Props {
 }
 
 export default function VideoFrame2({ prefix, interval = 15000 }: VideoFrame2Props) {
-  // Gather all media assets that start with the provided prefix.
+  // Gather all media assets that start with the provided prefix and
+  // construct URLs that point to the backend server instead of the Vite
+  // dev server. This allows other devices on the network to load the
+  // videos correctly.
   const sources = useMemo(() => {
-    const modules = (import.meta as any).glob('/public/videos/*', {
-      eager: true,
-      as: 'url',
-    });
+    const backend = ((import.meta as any).env.VITE_BACKEND_URL || '').replace(/\/$/, '');
+    const modules = (import.meta as any).glob('/public/videos/*', { eager: true });
     const slug = prefix.toLowerCase().replace(/\s+/g, '-');
-    return Object.entries(modules)
-      .filter(([path]) => path.toLowerCase().includes(slug))
-      .map(([path, url]) => {
-        const ext = path.split('.').pop()?.toLowerCase();
+    return Object.keys(modules)
+      .filter((path) => path.toLowerCase().includes(slug))
+      .map((path) => {
+        const file = path.split('/').pop() as string;
+        const ext = file.split('.').pop()?.toLowerCase();
         const type = ext === 'png' ? 'image' : 'video';
-        return { url: url as string, type };
+        return { url: `${backend}/videos/${file}` , type };
       });
   }, [prefix]);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     proxy: {
-      '/api': 'http://localhost:3001'
+      '/api': 'http://localhost:3001',
+      '/videos': 'http://localhost:3001'
     }
   }
 });


### PR DESCRIPTION
## Summary
- Fetch video URLs using `VITE_BACKEND_URL` so media loads from backend server
- Proxy `/videos` to backend during development
- Document `VITE_BACKEND_URL` in `.env.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4bc37f924833387c521d14bf88c7d