### PR TITLE
Fix VideoFrame2 glob to return URLs

### DIFF
--- a/src/components/VideoFrame2.tsx
+++ b/src/components/VideoFrame2.tsx
@@ -21,7 +21,10 @@ export default function VideoFrame2({ prefix, interval = 15000 }: VideoFrame2Pro
   // videos correctly.
   const sources = useMemo(() => {
     const backend = ((import.meta as any).env.VITE_BACKEND_URL || '').replace(/\/$/, '');
-    const modules = (import.meta as any).glob('/public/videos/*', { eager: true });
+    const modules = (import.meta as any).glob('/public/videos/*', {
+      eager: true,
+      as: 'url',
+    });
     const slug = prefix.toLowerCase().replace(/\s+/g, '-');
     return Object.keys(modules)
       .filter((path) => path.toLowerCase().includes(slug))


### PR DESCRIPTION
## Summary
- use Vite glob with `as: 'url'` in `VideoFrame2` to load video assets by URL

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b4be34cb2483338d3dfb5a19746573