### PR TITLE
fix: load videos from backend on network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ OPENAI_API_KEY=your_openai_api_key
 REDIS_URL=redis://localhost:6379
 PORT=3001
 OPENAI_MODEL=gpt-3.5-turbo
+VITE_BACKEND_URL=http://localhost:3001

--- a/server/index.js
+++ b/server/index.js
@@ -85,14 +85,17 @@ app.get('/api/chat/:conversationId', async (req, res) => {
   }
 });
 
-// Stream video files with Range support
+// Stream media files with Range support
 app.get('/videos/:name', (req, res) => {
-  const videoPath = path.join(process.cwd(), 'public', 'videos', req.params.name);
-  if (!fs.existsSync(videoPath)) {
+  const mediaPath = path.join(process.cwd(), 'public', 'videos', req.params.name);
+  if (!fs.existsSync(mediaPath)) {
     return res.sendStatus(404);
   }
+  const ext = path.extname(mediaPath).toLowerCase();
+  const contentType = ext === '.png' ? 'image/png' : 'video/mp4';
+
   const range = req.headers.range;
-  const stat = fs.statSync(videoPath);
+  const stat = fs.statSync(mediaPath);
   if (range) {
     const [startStr, endStr] = range.replace(/bytes=/, '').split('-');
     const start = parseInt(startStr, 10);
@@ -102,18 +105,18 @@ app.get('/videos/:name', (req, res) => {
       'Content-Range': `bytes ${start}-${end}/${stat.size}`,
       'Accept-Ranges': 'bytes',
       'Content-Length': chunkSize,
-      'Content-Type': 'video/mp4',
+      'Content-Type': contentType,
       'Cache-Control': 'no-store',
     });
-    fs.createReadStream(videoPath, { start, end }).pipe(res);
+    fs.createReadStream(mediaPath, { start, end }).pipe(res);
   } else {
     res.writeHead(200, {
       'Content-Length': stat.size,
-      'Content-Type': 'video/mp4',
+      'Content-Type': contentType,
       'Accept-Ranges': 'bytes',
       'Cache-Control': 'no-store',
     });
-    fs.createReadStream(videoPath).pipe(res);
+    fs.createReadStream(mediaPath).pipe(res);
   }
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     proxy: {
-      '/api': 'http://localhost:3001'
+      '/api': 'http://localhost:3001',
+      '/videos': 'http://localhost:3001'
     }
   }
 });


### PR DESCRIPTION
## Summary
- glob public videos as URLs and build backend video paths
- serve images with correct mime type in video handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4bc37f924833387c521d14bf88c7d