### PR TITLE
Limit OpenAI responses to 180 tokens

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -60,6 +60,7 @@ app.post('/api/chat', async (req, res) => {
       model,
       messages,
       stream: false,
+      max_tokens: 180,
     });
     const reply = completion.choices[0]?.message?.content || '';
     logger.info(`Chat reply conversationId=${conversationId} reply=${reply}`);


### PR DESCRIPTION
## Summary
- cap OpenAI chat completions at 180 tokens to constrain response length

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b60b8b7de88333b457c937077fefe3