### PR TITLE
Fix chat completion token limit parameter

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -182,7 +182,7 @@ app.post('/api/chat', async (req, res) => {
     } catch (storeErr) {
       logger.error(`Failed to persist user message for conversationId=${conversationId}: ${storeErr}`);
     }
-    const maxCompletionTokens =
+    const maxTokens =
       Number.isFinite(max_completion_tokens) && max_completion_tokens > 0
         ? Math.floor(max_completion_tokens)
         : 180;
@@ -190,7 +190,7 @@ app.post('/api/chat', async (req, res) => {
       model,
       messages,
       stream: false,
-      max_completion_tokens: maxCompletionTokens,
+      max_tokens: maxTokens,
     });
     const choice = completion.choices?.[0];
     const normalizedReply = normalizeAssistantChoice(choice);


### PR DESCRIPTION
## Summary
- update the chat endpoint to send the correct `max_tokens` parameter to the OpenAI chat completions API
- ensure user-provided `max_completion_tokens` values are still respected when present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5be9fcdfc8333b8777302fdd6d2fc