### PR TITLE
Fix unsupported max_tokens parameter error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -190,7 +190,7 @@ app.post('/api/chat', async (req, res) => {
       model,
       messages,
       stream: false,
-      max_tokens: maxTokens,
+      max_completion_tokens: maxTokens,
     });
     const choice = completion.choices?.[0];
     const normalizedReply = normalizeAssistantChoice(choice);


### PR DESCRIPTION
## Summary
- replace the deprecated `max_tokens` parameter in the chat completion request with `max_completion_tokens`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5c46ea15083339b6a2981ed2f8a24